### PR TITLE
Show ticket payment id in response

### DIFF
--- a/app/Http/Resources/TicketResource.php
+++ b/app/Http/Resources/TicketResource.php
@@ -19,6 +19,7 @@ class TicketResource extends JsonResource
             'created_at' => $this->created_at,
             'ticket_number' => $this->id,
             'available_tickets' => Redis::get('available_tickets'),
+            'payment_id' => $this->payment->id ?? null
         ];
     }
 }


### PR DESCRIPTION
Resolves https://github.com/DanJFletcher/parking-garage/issues/4

### What does this PR do?

Adds a payment_id in the ticket resource response. If there is no payment_id then the ticket has not been paid.